### PR TITLE
Update ServerProcessInspector.php

### DIFF
--- a/src/Swoole/ServerProcessInspector.php
+++ b/src/Swoole/ServerProcessInspector.php
@@ -57,10 +57,7 @@ class ServerProcessInspector
             'managerProcessId' => $managerProcessId
         ] = $this->serverStateFile->read();
 
-        $workerProcessIds = $this->exec->run('pgrep -P '.$managerProcessId);
-
-        $this->dispatcher->terminate(array_map('intval', $workerProcessIds), $this->terminateWait);
-        $this->dispatcher->terminate([(int) $managerProcessId, (int) $masterProcessId]);
+        $this->dispatcher->terminate((int) $masterProcessId, $this->terminateWait);
 
         return true;
     }


### PR DESCRIPTION
Sending a `TERM` signal to the master process will start shutting down workers, the manager and finally the master process in that order, while also waiting for ongoing requests.

New requests _during_ shutdown, will still be accepted but will eventually be reset (`curl: (56) Recv failure: Connection reset by peer`). This is an issue in Swoole